### PR TITLE
Context-aware `CommandNode#canUse` method

### DIFF
--- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
+++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
@@ -386,19 +386,29 @@ public class CommandDispatcher<S> {
                     final CommandContextBuilder<S> childContext = new CommandContextBuilder<>(this, source, child.getRedirect(), reader.getCursor());
                     final ParseResults<S> parse = parseNodes(child.getRedirect(), reader, childContext);
                     context.withChild(parse.getContext());
-                    return new ParseResults<>(context, parse.getReader(), parse.getExceptions());
+                    final ParseResults<S> redirect = new ParseResults<>(context, parse.getReader(), parse.getExceptions());
+                    if (child.canUse(redirect)) {
+                        return redirect;
+                    }
                 } else {
                     final ParseResults<S> parse = parseNodes(child, reader, context);
+                    if (!child.canUse(parse)) {
+                        continue;
+                    }
                     if (potentials == null) {
                         potentials = new ArrayList<>(1);
                     }
                     potentials.add(parse);
                 }
             } else {
+                final ParseResults<S> parse = new ParseResults<>(context, reader, Collections.emptyMap());
+                if (!child.canUse(parse)) {
+                    continue;
+                }
                 if (potentials == null) {
                     potentials = new ArrayList<>(1);
                 }
-                potentials.add(new ParseResults<>(context, reader, Collections.emptyMap()));
+                potentials.add(parse);
             }
         }
 

--- a/src/main/java/com/mojang/brigadier/builder/ArgumentBuilder.java
+++ b/src/main/java/com/mojang/brigadier/builder/ArgumentBuilder.java
@@ -72,7 +72,7 @@ public abstract class ArgumentBuilder<S, T extends ArgumentBuilder<S, T>> {
         return contextRequirement;
     }
 
-  public T redirect(final CommandNode<S> target) {
+    public T redirect(final CommandNode<S> target) {
         return forward(target, null, false);
     }
 

--- a/src/main/java/com/mojang/brigadier/builder/ArgumentBuilder.java
+++ b/src/main/java/com/mojang/brigadier/builder/ArgumentBuilder.java
@@ -4,6 +4,7 @@
 package com.mojang.brigadier.builder;
 
 import com.mojang.brigadier.Command;
+import com.mojang.brigadier.ParseResults;
 import com.mojang.brigadier.RedirectModifier;
 import com.mojang.brigadier.SingleRedirectModifier;
 import com.mojang.brigadier.tree.CommandNode;
@@ -17,6 +18,7 @@ public abstract class ArgumentBuilder<S, T extends ArgumentBuilder<S, T>> {
     private final RootCommandNode<S> arguments = new RootCommandNode<>();
     private Command<S> command;
     private Predicate<S> requirement = s -> true;
+    private Predicate<ParseResults<S>> contextRequirement = parse -> true;
     private CommandNode<S> target;
     private RedirectModifier<S> modifier = null;
     private boolean forks;
@@ -61,7 +63,16 @@ public abstract class ArgumentBuilder<S, T extends ArgumentBuilder<S, T>> {
         return requirement;
     }
 
-    public T redirect(final CommandNode<S> target) {
+    public T requiresWithContext(final Predicate<ParseResults<S>> requirement) {
+        this.contextRequirement = requirement;
+        return getThis();
+    }
+
+    public Predicate<ParseResults<S>> getContextRequirement() {
+        return contextRequirement;
+    }
+
+  public T redirect(final CommandNode<S> target) {
         return forward(target, null, false);
     }
 

--- a/src/main/java/com/mojang/brigadier/builder/LiteralArgumentBuilder.java
+++ b/src/main/java/com/mojang/brigadier/builder/LiteralArgumentBuilder.java
@@ -28,7 +28,7 @@ public class LiteralArgumentBuilder<S> extends ArgumentBuilder<S, LiteralArgumen
 
     @Override
     public LiteralCommandNode<S> build() {
-        final LiteralCommandNode<S> result = new LiteralCommandNode<>(getLiteral(), getCommand(), getRequirement(), getRedirect(), getRedirectModifier(), isFork());
+        final LiteralCommandNode<S> result = new LiteralCommandNode<>(getLiteral(), getCommand(), getRequirement(), getContextRequirement(), getRedirect(), getRedirectModifier(), isFork());
 
         for (final CommandNode<S> argument : getArguments()) {
             result.addChild(argument);

--- a/src/main/java/com/mojang/brigadier/builder/RequiredArgumentBuilder.java
+++ b/src/main/java/com/mojang/brigadier/builder/RequiredArgumentBuilder.java
@@ -45,7 +45,7 @@ public class RequiredArgumentBuilder<S, T> extends ArgumentBuilder<S, RequiredAr
     }
 
     public ArgumentCommandNode<S, T> build() {
-        final ArgumentCommandNode<S, T> result = new ArgumentCommandNode<>(getName(), getType(), getCommand(), getRequirement(), getRedirect(), getRedirectModifier(), isFork(), getSuggestionsProvider());
+        final ArgumentCommandNode<S, T> result = new ArgumentCommandNode<>(getName(), getType(), getCommand(), getRequirement(), getContextRequirement(), getRedirect(), getRedirectModifier(), isFork(), getSuggestionsProvider());
 
         for (final CommandNode<S> argument : getArguments()) {
             result.addChild(argument);

--- a/src/main/java/com/mojang/brigadier/context/CommandContext.java
+++ b/src/main/java/com/mojang/brigadier/context/CommandContext.java
@@ -141,7 +141,11 @@ public class CommandContext<S> {
         return nodes;
     }
 
-    public boolean hasNodes() {
+    public Map<String, ParsedArgument<S, ?>> getArguments() {
+        return arguments;
+    }
+
+  public boolean hasNodes() {
         return !nodes.isEmpty();
     }
 

--- a/src/main/java/com/mojang/brigadier/tree/ArgumentCommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/ArgumentCommandNode.java
@@ -4,6 +4,7 @@
 package com.mojang.brigadier.tree;
 
 import com.mojang.brigadier.Command;
+import com.mojang.brigadier.ParseResults;
 import com.mojang.brigadier.RedirectModifier;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.arguments.ArgumentType;
@@ -27,6 +28,13 @@ public class ArgumentCommandNode<S, T> extends CommandNode<S> {
     private final String name;
     private final ArgumentType<T> type;
     private final SuggestionProvider<S> customSuggestions;
+
+    public ArgumentCommandNode(final String name, final ArgumentType<T> type, final Command<S> command, final Predicate<S> requirement, final Predicate<ParseResults<S>> contextRequirement, final CommandNode<S> redirect, final RedirectModifier<S> modifier, final boolean forks, final SuggestionProvider<S> customSuggestions) {
+        super(command, requirement, contextRequirement, redirect, modifier, forks);
+        this.name = name;
+        this.type = type;
+        this.customSuggestions = customSuggestions;
+    }
 
     public ArgumentCommandNode(final String name, final ArgumentType<T> type, final Command<S> command, final Predicate<S> requirement, final CommandNode<S> redirect, final RedirectModifier<S> modifier, final boolean forks, final SuggestionProvider<S> customSuggestions) {
         super(command, requirement, redirect, modifier, forks);

--- a/src/main/java/com/mojang/brigadier/tree/CommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/CommandNode.java
@@ -156,6 +156,10 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
         return requirement;
     }
 
+    public Predicate<ParseResults<S>> getContextRequirement() {
+        return contextRequirement;
+    }
+
     public abstract String getName();
 
     public abstract String getUsageText();

--- a/src/main/java/com/mojang/brigadier/tree/LiteralCommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/LiteralCommandNode.java
@@ -4,6 +4,7 @@
 package com.mojang.brigadier.tree;
 
 import com.mojang.brigadier.Command;
+import com.mojang.brigadier.ParseResults;
 import com.mojang.brigadier.RedirectModifier;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
@@ -24,6 +25,11 @@ public class LiteralCommandNode<S> extends CommandNode<S> {
 
     public LiteralCommandNode(final String literal, final Command<S> command, final Predicate<S> requirement, final CommandNode<S> redirect, final RedirectModifier<S> modifier, final boolean forks) {
         super(command, requirement, redirect, modifier, forks);
+        this.literal = literal;
+    }
+
+    public LiteralCommandNode(final String literal, final Command<S> command, final Predicate<S> requirement, final Predicate<ParseResults<S>> contextRequirement, final CommandNode<S> redirect, final RedirectModifier<S> modifier, final boolean forks) {
+        super(command, requirement, contextRequirement, redirect, modifier, forks);
         this.literal = literal;
     }
 


### PR DESCRIPTION
See https://github.com/VelocityPowered/Velocity/issues/432

This introduces new API, but doesn't change any parsing behavior unless a `CommandNode` opts to override `canUse(ParseResults)`. This is mostly an internal method to support context-aware permission checks on Velocity.

Brigadier has been unmaintained for 2 years. I doubt they would merge this change any time soon (another reason this would be a nono for Mojang is that it duplicates a method when they can break compatibility and "adapt" the original method for this use case).