### PR TITLE
Fix childless redirects

### DIFF
--- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
+++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
@@ -401,6 +401,10 @@ public class CommandDispatcher<S> {
                     potentials.add(parse);
                 }
             } else {
+                final CommandNode<S> redirect = child.getRedirect();
+                if (redirect != null && redirect.getCommand() != null) {
+                    context.withCommand(redirect.getCommand());
+                }
                 final ParseResults<S> parse = new ParseResults<>(context, reader, Collections.emptyMap());
                 if (!child.canUse(parse)) {
                     continue;

--- a/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
+++ b/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
@@ -3,17 +3,6 @@
 
 package com.mojang.brigadier;
 
-import com.google.common.collect.Lists;
-import com.mojang.brigadier.context.CommandContext;
-import com.mojang.brigadier.context.CommandContextBuilder;
-import com.mojang.brigadier.exceptions.CommandSyntaxException;
-import com.mojang.brigadier.tree.LiteralCommandNode;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-
 import static com.mojang.brigadier.arguments.IntegerArgumentType.integer;
 import static com.mojang.brigadier.builder.LiteralArgumentBuilder.literal;
 import static com.mojang.brigadier.builder.RequiredArgumentBuilder.argument;
@@ -31,6 +20,19 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Lists;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.context.CommandContextBuilder;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.tree.CommandNode;
+import com.mojang.brigadier.tree.LiteralCommandNode;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CommandDispatcherTest {
@@ -200,6 +202,15 @@ public class CommandDispatcherTest {
         final ParseResults<Object> parse = subject.parse("foo ", source);
         assertThat(parse.getReader().getRemaining(), equalTo(" "));
         assertThat(parse.getContext().getNodes().size(), is(1));
+    }
+
+    @Test
+    public void testParseChildlessRedirect() throws Exception {
+        final CommandNode<Object> target = subject.register(literal("foo").executes(command));
+        subject.register(literal("bar").redirect(target));
+
+        final ParseResults<Object> parse = subject.parse("bar", source);
+        assertThat(parse.getContext().getCommand(), equalTo(target.getCommand()));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
+++ b/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
@@ -3,6 +3,18 @@
 
 package com.mojang.brigadier;
 
+import com.google.common.collect.Lists;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.context.CommandContextBuilder;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.tree.CommandNode;
+import com.mojang.brigadier.tree.LiteralCommandNode;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
 import static com.mojang.brigadier.arguments.IntegerArgumentType.integer;
 import static com.mojang.brigadier.builder.LiteralArgumentBuilder.literal;
 import static com.mojang.brigadier.builder.RequiredArgumentBuilder.argument;
@@ -20,19 +32,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import com.google.common.collect.Lists;
-import com.mojang.brigadier.context.CommandContext;
-import com.mojang.brigadier.context.CommandContextBuilder;
-import com.mojang.brigadier.exceptions.CommandSyntaxException;
-import com.mojang.brigadier.tree.CommandNode;
-import com.mojang.brigadier.tree.LiteralCommandNode;
-import java.util.Collections;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CommandDispatcherTest {
@@ -207,10 +206,11 @@ public class CommandDispatcherTest {
     @Test
     public void testParseChildlessRedirect() throws Exception {
         final CommandNode<Object> target = subject.register(literal("foo").executes(command));
-        subject.register(literal("bar").redirect(target));
+        final CommandNode<Object> redirect = subject.register(literal("redirect").redirect(target));
 
-        final ParseResults<Object> parse = subject.parse("bar", source);
+        final ParseResults<Object> parse = subject.parse("redirect", source);
         assertThat(parse.getContext().getCommand(), equalTo(target.getCommand()));
+        assertThat(parse.getContext().getNodes().get(0).getNode(), equalTo(redirect));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Makes parseNodes consider the Command of a redirect target when no
contents can be read. For example, given a "foo" literal with a non-null
Command, and a "bar" literal forwarding to the "foo" node, the parse
results' context contains the command of the "foo" node, and the parsed node
is the "bar" node.

This follows the same logic as a regular redirect.
`CommandDispatcherTest#testExecuteRedirectedMultipleTimes` highlights
the parse tree contains the redirected node (`redirectNode`), while
the executed Command is that of the target node (`concreteNode`).

Fixes https://github.com/Mojang/brigadier/issues/46
Required by https://github.com/VelocityPowered/Velocity/pull/433