### PR TITLE
Replaced unneeded substring comparison by regionMatches

### DIFF
--- a/src/main/java/com/mojang/brigadier/tree/LiteralCommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/LiteralCommandNode.java
@@ -50,15 +50,13 @@ public class LiteralCommandNode<S> extends CommandNode<S> {
 
     private int parse(final StringReader reader) {
         final int start = reader.getCursor();
-        if (reader.canRead(literal.length())) {
+        if (literal.regionMatches(0, reader.getString(), start, literal.length())) {
             final int end = start + literal.length();
-            if (reader.getString().substring(start, end).equals(literal)) {
-                reader.setCursor(end);
-                if (!reader.canRead() || reader.peek() == ' ') {
-                    return end;
-                } else {
-                    reader.setCursor(start);
-                }
+            reader.setCursor(end);
+            if (!reader.canRead() || reader.peek() == ' ') {
+                return end;
+            } else {
+                reader.setCursor(start);
             }
         }
         return -1;


### PR DESCRIPTION
Speeds up literal node parsing. Similar motivation as
https://github.com/VelocityPowered/brigadier/commit/0d28b8e9dcbaeea5e8bdd5d5ae7807fd0def5f60.

Part of https://github.com/VelocityPowered/Velocity/pull/433.