### PR TITLE
Add forSuggestions attribute to CommandContextBuilder

### DIFF
--- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
+++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
@@ -343,7 +343,11 @@ public class CommandDispatcher<S> {
      * @see #execute(String, Object)
      */
     public ParseResults<S> parse(final StringReader command, final S source) {
-        final CommandContextBuilder<S> context = new CommandContextBuilder<>(this, source, root, command.getCursor());
+        return parse(command, source, false);
+    }
+
+    public ParseResults<S> parse(final StringReader command, final S source, final boolean forSuggestions) {
+        final CommandContextBuilder<S> context = new CommandContextBuilder<>(this, source, root, command.getCursor(), forSuggestions);
         return parseNodes(root, command, context);
     }
 
@@ -383,7 +387,7 @@ public class CommandDispatcher<S> {
             if (reader.canRead(child.getRedirect() == null ? 2 : 1)) {
                 reader.skip();
                 if (child.getRedirect() != null) {
-                    final CommandContextBuilder<S> childContext = new CommandContextBuilder<>(this, source, child.getRedirect(), reader.getCursor());
+                    final CommandContextBuilder<S> childContext = new CommandContextBuilder<>(this, source, child.getRedirect(), reader.getCursor(), contextSoFar.isForSuggestions());
                     final ParseResults<S> parse = parseNodes(child.getRedirect(), reader, childContext);
                     context.withChild(parse.getContext());
                     final ParseResults<S> redirect = new ParseResults<>(context, parse.getReader(), parse.getExceptions());

--- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
+++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
@@ -315,6 +315,10 @@ public class CommandDispatcher<S> {
         return parse(new StringReader(command), source);
     }
 
+    public ParseResults<S> parse(final String command, final S source, final boolean forSuggestions) {
+        return parse(new StringReader(command), source, forSuggestions);
+    }
+
     /**
      * Parses a given command.
      *

--- a/src/main/java/com/mojang/brigadier/context/CommandContextBuilder.java
+++ b/src/main/java/com/mojang/brigadier/context/CommandContextBuilder.java
@@ -18,6 +18,7 @@ public class CommandContextBuilder<S> {
     private final CommandNode<S> rootNode;
     private final List<ParsedCommandNode<S>> nodes = new ArrayList<>();
     private final CommandDispatcher<S> dispatcher;
+    private final boolean forSuggestions;
     private S source;
     private Command<S> command;
     private CommandContextBuilder<S> child;
@@ -25,11 +26,16 @@ public class CommandContextBuilder<S> {
     private RedirectModifier<S> modifier = null;
     private boolean forks;
 
-    public CommandContextBuilder(final CommandDispatcher<S> dispatcher, final S source, final CommandNode<S> rootNode, final int start) {
+    public CommandContextBuilder(final CommandDispatcher<S> dispatcher, final S source, final CommandNode<S> rootNode, final int start, final boolean forSuggestions) {
         this.rootNode = rootNode;
         this.dispatcher = dispatcher;
         this.source = source;
+        this.forSuggestions = false;
         this.range = StringRange.at(start);
+    }
+
+    public CommandContextBuilder(final CommandDispatcher<S> dispatcher, final S source, final CommandNode<S> rootNode, final int start) {
+        this(dispatcher, source, rootNode, start, false);
     }
 
     public CommandContextBuilder<S> withSource(final S source) {
@@ -68,7 +74,7 @@ public class CommandContextBuilder<S> {
     }
 
     public CommandContextBuilder<S> copy() {
-        final CommandContextBuilder<S> copy = new CommandContextBuilder<>(dispatcher, source, rootNode, range.getStart());
+        final CommandContextBuilder<S> copy = new CommandContextBuilder<>(dispatcher, source, rootNode, range.getStart(), forSuggestions);
         copy.command = command;
         copy.arguments.putAll(arguments);
         copy.nodes.addAll(nodes);
@@ -113,6 +119,10 @@ public class CommandContextBuilder<S> {
 
     public StringRange getRange() {
         return range;
+    }
+
+    public boolean isForSuggestions() {
+        return forSuggestions;
     }
 
     public SuggestionContext<S> findSuggestionContext(final int cursor) {

--- a/src/main/java/com/mojang/brigadier/context/CommandContextBuilder.java
+++ b/src/main/java/com/mojang/brigadier/context/CommandContextBuilder.java
@@ -30,7 +30,7 @@ public class CommandContextBuilder<S> {
         this.rootNode = rootNode;
         this.dispatcher = dispatcher;
         this.source = source;
-        this.forSuggestions = false;
+        this.forSuggestions = forSuggestions;
         this.range = StringRange.at(start);
     }
 


### PR DESCRIPTION
Currently parsing and execution/suggestions are performed separately.
This separation of concerns is good, but sometimes can lead to duplicate
work. For example, it is necessary to perform a duplicate permissions
checking call when creating the suggestions for an argument node.
Introducing this change as a boolean field instead of modifying the
parsing logic leads to better maintainability.

---

This will allow us to remove a duplicate `Command#hasPermission` call when creating suggestions in Velocity.

Part of https://github.com/VelocityPowered/Velocity/pull/433.