### PR TITLE
Fix suggestions

### DIFF
--- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
+++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
@@ -386,10 +386,10 @@ public class CommandDispatcher<S> {
                     final CommandContextBuilder<S> childContext = new CommandContextBuilder<>(this, source, child.getRedirect(), reader.getCursor());
                     final ParseResults<S> parse = parseNodes(child.getRedirect(), reader, childContext);
                     context.withChild(parse.getContext());
-                    if (child.canUse(context)) {
+                    if (child.canUse(context, parse.getReader())) {
                         return new ParseResults<>(context, parse.getReader(), parse.getExceptions());
                     }
-                } else if (child.canUse(context)) {
+                } else if (child.canUse(context, reader)) {
                     final ParseResults<S> parse = parseNodes(child, reader, context);
                     if (potentials == null) {
                         potentials = new ArrayList<>(1);
@@ -401,7 +401,7 @@ public class CommandDispatcher<S> {
                 if (redirect != null && redirect.getCommand() != null) {
                     context.withCommand(redirect.getCommand());
                 }
-                if (!child.canUse(context)) {
+                if (!child.canUse(context, reader)) {
                     continue;
                 }
                 final ParseResults<S> parse = new ParseResults<>(context, reader, Collections.emptyMap());
@@ -608,7 +608,9 @@ public class CommandDispatcher<S> {
             }
             // We don't know the real range of the parsed contents; default to an empty range.
             final CommandContextBuilder<S> nodeContext = context.copy().withNode(node, StringRange.at(start));
-            if (!node.canUse(nodeContext)) {
+            final StringReader reader = new StringReader(truncatedInput);
+            reader.setCursor(start);
+            if (!node.canUse(nodeContext, reader)) {
                 futures[i++] = future;
                 continue;
             }

--- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
+++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
@@ -6,6 +6,7 @@ package com.mojang.brigadier;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.context.CommandContextBuilder;
+import com.mojang.brigadier.context.StringRange;
 import com.mojang.brigadier.context.SuggestionContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.Suggestions;
@@ -601,6 +602,16 @@ public class CommandDispatcher<S> {
         int i = 0;
         for (final CommandNode<S> node : parent.getChildren()) {
             CompletableFuture<Suggestions> future = Suggestions.empty();
+            if (!node.canUse(context.getSource())) {
+                futures[i++] = future;
+                continue;
+            }
+            // We don't know the real range of the parsed contents; default to an empty range.
+            final CommandContextBuilder<S> nodeContext = context.copy().withNode(node, StringRange.at(start));
+            if (!node.canUse(nodeContext)) {
+                futures[i++] = future;
+                continue;
+            }
             try {
                 future = node.listSuggestions(context.build(truncatedInput), new SuggestionsBuilder(truncatedInput, start));
             } catch (final CommandSyntaxException ignored) {

--- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
+++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
@@ -13,7 +13,6 @@ import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import com.mojang.brigadier.tree.RootCommandNode;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -386,15 +385,11 @@ public class CommandDispatcher<S> {
                     final CommandContextBuilder<S> childContext = new CommandContextBuilder<>(this, source, child.getRedirect(), reader.getCursor());
                     final ParseResults<S> parse = parseNodes(child.getRedirect(), reader, childContext);
                     context.withChild(parse.getContext());
-                    final ParseResults<S> redirect = new ParseResults<>(context, parse.getReader(), parse.getExceptions());
-                    if (child.canUse(redirect)) {
-                        return redirect;
+                    if (child.canUse(context)) {
+                        return new ParseResults<>(context, parse.getReader(), parse.getExceptions());
                     }
-                } else {
+                } else if (child.canUse(context)) {
                     final ParseResults<S> parse = parseNodes(child, reader, context);
-                    if (!child.canUse(parse)) {
-                        continue;
-                    }
                     if (potentials == null) {
                         potentials = new ArrayList<>(1);
                     }
@@ -405,10 +400,10 @@ public class CommandDispatcher<S> {
                 if (redirect != null && redirect.getCommand() != null) {
                     context.withCommand(redirect.getCommand());
                 }
-                final ParseResults<S> parse = new ParseResults<>(context, reader, Collections.emptyMap());
-                if (!child.canUse(parse)) {
+                if (!child.canUse(context)) {
                     continue;
                 }
+                final ParseResults<S> parse = new ParseResults<>(context, reader, Collections.emptyMap());
                 if (potentials == null) {
                     potentials = new ArrayList<>(1);
                 }

--- a/src/main/java/com/mojang/brigadier/builder/ArgumentBuilder.java
+++ b/src/main/java/com/mojang/brigadier/builder/ArgumentBuilder.java
@@ -4,6 +4,7 @@
 package com.mojang.brigadier.builder;
 
 import com.mojang.brigadier.Command;
+import com.mojang.brigadier.ImmutableStringReader;
 import com.mojang.brigadier.RedirectModifier;
 import com.mojang.brigadier.SingleRedirectModifier;
 import com.mojang.brigadier.context.CommandContextBuilder;
@@ -12,13 +13,14 @@ import com.mojang.brigadier.tree.RootCommandNode;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
 public abstract class ArgumentBuilder<S, T extends ArgumentBuilder<S, T>> {
     private final RootCommandNode<S> arguments = new RootCommandNode<>();
     private Command<S> command;
     private Predicate<S> requirement = s -> true;
-    private Predicate<CommandContextBuilder<S>> contextRequirement = context -> true;
+    private BiPredicate<CommandContextBuilder<S>, ImmutableStringReader> contextRequirement = (context, reader) -> true;
     private CommandNode<S> target;
     private RedirectModifier<S> modifier = null;
     private boolean forks;
@@ -63,12 +65,12 @@ public abstract class ArgumentBuilder<S, T extends ArgumentBuilder<S, T>> {
         return requirement;
     }
 
-    public T requiresWithContext(final Predicate<CommandContextBuilder<S>> requirement) {
+    public T requiresWithContext(final BiPredicate<CommandContextBuilder<S>, ImmutableStringReader> requirement) {
         this.contextRequirement = requirement;
         return getThis();
     }
 
-    public Predicate<CommandContextBuilder<S>> getContextRequirement() {
+    public BiPredicate<CommandContextBuilder<S>, ImmutableStringReader> getContextRequirement() {
         return contextRequirement;
     }
 

--- a/src/main/java/com/mojang/brigadier/builder/ArgumentBuilder.java
+++ b/src/main/java/com/mojang/brigadier/builder/ArgumentBuilder.java
@@ -4,9 +4,9 @@
 package com.mojang.brigadier.builder;
 
 import com.mojang.brigadier.Command;
-import com.mojang.brigadier.ParseResults;
 import com.mojang.brigadier.RedirectModifier;
 import com.mojang.brigadier.SingleRedirectModifier;
+import com.mojang.brigadier.context.CommandContextBuilder;
 import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.RootCommandNode;
 
@@ -18,7 +18,7 @@ public abstract class ArgumentBuilder<S, T extends ArgumentBuilder<S, T>> {
     private final RootCommandNode<S> arguments = new RootCommandNode<>();
     private Command<S> command;
     private Predicate<S> requirement = s -> true;
-    private Predicate<ParseResults<S>> contextRequirement = parse -> true;
+    private Predicate<CommandContextBuilder<S>> contextRequirement = context -> true;
     private CommandNode<S> target;
     private RedirectModifier<S> modifier = null;
     private boolean forks;
@@ -63,12 +63,12 @@ public abstract class ArgumentBuilder<S, T extends ArgumentBuilder<S, T>> {
         return requirement;
     }
 
-    public T requiresWithContext(final Predicate<ParseResults<S>> requirement) {
+    public T requiresWithContext(final Predicate<CommandContextBuilder<S>> requirement) {
         this.contextRequirement = requirement;
         return getThis();
     }
 
-    public Predicate<ParseResults<S>> getContextRequirement() {
+    public Predicate<CommandContextBuilder<S>> getContextRequirement() {
         return contextRequirement;
     }
 

--- a/src/main/java/com/mojang/brigadier/context/CommandContextBuilder.java
+++ b/src/main/java/com/mojang/brigadier/context/CommandContextBuilder.java
@@ -9,6 +9,7 @@ import com.mojang.brigadier.RedirectModifier;
 import com.mojang.brigadier.tree.CommandNode;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/mojang/brigadier/tree/ArgumentCommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/ArgumentCommandNode.java
@@ -29,7 +29,7 @@ public class ArgumentCommandNode<S, T> extends CommandNode<S> {
     private final ArgumentType<T> type;
     private final SuggestionProvider<S> customSuggestions;
 
-    public ArgumentCommandNode(final String name, final ArgumentType<T> type, final Command<S> command, final Predicate<S> requirement, final Predicate<ParseResults<S>> contextRequirement, final CommandNode<S> redirect, final RedirectModifier<S> modifier, final boolean forks, final SuggestionProvider<S> customSuggestions) {
+    public ArgumentCommandNode(final String name, final ArgumentType<T> type, final Command<S> command, final Predicate<S> requirement, final Predicate<CommandContextBuilder<S>> contextRequirement, final CommandNode<S> redirect, final RedirectModifier<S> modifier, final boolean forks, final SuggestionProvider<S> customSuggestions) {
         super(command, requirement, contextRequirement, redirect, modifier, forks);
         this.name = name;
         this.type = type;

--- a/src/main/java/com/mojang/brigadier/tree/ArgumentCommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/ArgumentCommandNode.java
@@ -4,6 +4,7 @@
 package com.mojang.brigadier.tree;
 
 import com.mojang.brigadier.Command;
+import com.mojang.brigadier.ImmutableStringReader;
 import com.mojang.brigadier.ParseResults;
 import com.mojang.brigadier.RedirectModifier;
 import com.mojang.brigadier.StringReader;
@@ -19,6 +20,7 @@ import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
 public class ArgumentCommandNode<S, T> extends CommandNode<S> {
@@ -29,7 +31,7 @@ public class ArgumentCommandNode<S, T> extends CommandNode<S> {
     private final ArgumentType<T> type;
     private final SuggestionProvider<S> customSuggestions;
 
-    public ArgumentCommandNode(final String name, final ArgumentType<T> type, final Command<S> command, final Predicate<S> requirement, final Predicate<CommandContextBuilder<S>> contextRequirement, final CommandNode<S> redirect, final RedirectModifier<S> modifier, final boolean forks, final SuggestionProvider<S> customSuggestions) {
+    public ArgumentCommandNode(final String name, final ArgumentType<T> type, final Command<S> command, final Predicate<S> requirement, final BiPredicate<CommandContextBuilder<S>, ImmutableStringReader> contextRequirement, final CommandNode<S> redirect, final RedirectModifier<S> modifier, final boolean forks, final SuggestionProvider<S> customSuggestions) {
         super(command, requirement, contextRequirement, redirect, modifier, forks);
         this.name = name;
         this.type = type;

--- a/src/main/java/com/mojang/brigadier/tree/CommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/CommandNode.java
@@ -5,7 +5,6 @@ package com.mojang.brigadier.tree;
 
 import com.mojang.brigadier.AmbiguityConsumer;
 import com.mojang.brigadier.Command;
-import com.mojang.brigadier.ParseResults;
 import com.mojang.brigadier.RedirectModifier;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.builder.ArgumentBuilder;
@@ -23,7 +22,7 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
     private Map<String, CommandNode<S>> children = new TreeMap<>();
     private Map<String, ArgumentCommandNode<S, ?>> arguments = new LinkedHashMap<>();
     private final Predicate<S> requirement;
-    private final Predicate<ParseResults<S>> contextRequirement;
+    private final Predicate<CommandContextBuilder<S>> contextRequirement;
     private final CommandNode<S> redirect;
     private final RedirectModifier<S> modifier;
     private final boolean forks;
@@ -33,13 +32,13 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
     protected CommandNode(final Command<S> command, final Predicate<S> requirement, final CommandNode<S> redirect, final RedirectModifier<S> modifier, final boolean forks) {
         this.command = command;
         this.requirement = requirement;
-        this.contextRequirement = parse -> true;
+        this.contextRequirement = context -> true;
         this.redirect = redirect;
         this.modifier = modifier;
         this.forks = forks;
     }
 
-    protected CommandNode(final Command<S> command, final Predicate<S> requirement, final Predicate<ParseResults<S>> contextRequirement, final CommandNode<S> redirect, final RedirectModifier<S> modifier, final boolean forks) {
+    protected CommandNode(final Command<S> command, final Predicate<S> requirement, final Predicate<CommandContextBuilder<S>> contextRequirement, final CommandNode<S> redirect, final RedirectModifier<S> modifier, final boolean forks) {
         this.command = command;
         this.requirement = requirement;
         this.contextRequirement = contextRequirement;
@@ -72,8 +71,8 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
         return requirement.test(source);
     }
 
-    public boolean canUse(final ParseResults<S> parse) {
-        return contextRequirement.test(parse);
+    public boolean canUse(final CommandContextBuilder<S> context) {
+        return contextRequirement.test(context);
     }
 
     public void addChild(final CommandNode<S> node) {
@@ -154,10 +153,6 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
 
     public Predicate<S> getRequirement() {
         return requirement;
-    }
-
-    public Predicate<ParseResults<S>> getContextRequirement() {
-        return contextRequirement;
     }
 
     public abstract String getName();

--- a/src/main/java/com/mojang/brigadier/tree/CommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/CommandNode.java
@@ -155,6 +155,10 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
         return requirement;
     }
 
+    public Predicate<CommandContextBuilder<S>> getContextRequirement() {
+        return contextRequirement;
+    }
+
     public abstract String getName();
 
     public abstract String getUsageText();

--- a/src/main/java/com/mojang/brigadier/tree/LiteralCommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/LiteralCommandNode.java
@@ -28,7 +28,7 @@ public class LiteralCommandNode<S> extends CommandNode<S> {
         this.literal = literal;
     }
 
-    public LiteralCommandNode(final String literal, final Command<S> command, final Predicate<S> requirement, final Predicate<ParseResults<S>> contextRequirement, final CommandNode<S> redirect, final RedirectModifier<S> modifier, final boolean forks) {
+    public LiteralCommandNode(final String literal, final Command<S> command, final Predicate<S> requirement, final Predicate<CommandContextBuilder<S>> contextRequirement, final CommandNode<S> redirect, final RedirectModifier<S> modifier, final boolean forks) {
         super(command, requirement, contextRequirement, redirect, modifier, forks);
         this.literal = literal;
     }

--- a/src/main/java/com/mojang/brigadier/tree/LiteralCommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/LiteralCommandNode.java
@@ -4,6 +4,7 @@
 package com.mojang.brigadier.tree;
 
 import com.mojang.brigadier.Command;
+import com.mojang.brigadier.ImmutableStringReader;
 import com.mojang.brigadier.ParseResults;
 import com.mojang.brigadier.RedirectModifier;
 import com.mojang.brigadier.StringReader;
@@ -18,6 +19,7 @@ import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
 public class LiteralCommandNode<S> extends CommandNode<S> {
@@ -28,7 +30,7 @@ public class LiteralCommandNode<S> extends CommandNode<S> {
         this.literal = literal;
     }
 
-    public LiteralCommandNode(final String literal, final Command<S> command, final Predicate<S> requirement, final Predicate<CommandContextBuilder<S>> contextRequirement, final CommandNode<S> redirect, final RedirectModifier<S> modifier, final boolean forks) {
+    public LiteralCommandNode(final String literal, final Command<S> command, final Predicate<S> requirement, final BiPredicate<CommandContextBuilder<S>, ImmutableStringReader> contextRequirement, final CommandNode<S> redirect, final RedirectModifier<S> modifier, final boolean forks) {
         super(command, requirement, contextRequirement, redirect, modifier, forks);
         this.literal = literal;
     }

--- a/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
+++ b/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
@@ -217,9 +217,10 @@ public class CommandDispatcherTest {
 
     @Test
     public void testParseContextImpermissibleLiteral() throws Exception {
-        subject.register(literal("foo").requiresWithContext(context -> {
+        subject.register(literal("foo").requiresWithContext((context, reader) -> {
             assertThat(context.getNodes().size(), is(1));
             assertThat(context.getRange(), equalTo(StringRange.between(0, 3)));
+            assertThat(reader.getCursor(), is(3));
             return false;
         }));
 
@@ -232,10 +233,11 @@ public class CommandDispatcherTest {
     public void testParseContextImpermissibleArgument() throws Exception {
         subject.register(literal("foo")
             .then(argument("bar", integer())
-                .requiresWithContext(context -> {
+                .requiresWithContext((context, reader) -> {
                     assertThat(context.getNodes().size(), is(2));
                     assertThat(context.getArguments().size(), is(1));
                     assertThat(context.getRange(), equalTo(StringRange.between(0, 5)));
+                    assertThat(reader.getCursor(), is(5));
                     return false;
                 })
             )

--- a/src/test/java/com/mojang/brigadier/CommandSuggestionsTest.java
+++ b/src/test/java/com/mojang/brigadier/CommandSuggestionsTest.java
@@ -129,9 +129,10 @@ public class CommandSuggestionsTest {
     public void getCompletionSuggestions_rootCommands_impermissibleContext() throws Exception {
         subject.register(
             literal("foo")
-                .requiresWithContext(context -> {
+                .requiresWithContext((context, reader) -> {
                     assertThat(context.getRange(), equalTo(StringRange.at(0)));
                     assertThat(context.getNodes().size(), is(1));
+                    assertThat(reader.getCursor(), is(0));
                     return false;
                 })
         );
@@ -249,9 +250,10 @@ public class CommandSuggestionsTest {
         subject.register(
             literal("parent")
                 .then(literal("foo")
-                    .requiresWithContext(context -> {
+                    .requiresWithContext((context, reader) -> {
                         assertThat(context.getRange(), equalTo(StringRange.between(0, 7)));
                         assertThat(context.getNodes().size(), is(2));
+                        assertThat(reader.getCursor(), is(7));
                         return false;
                     })
                 )
@@ -269,12 +271,13 @@ public class CommandSuggestionsTest {
         subject.register(
             literal("parent")
                 .then(argument("foo", integer())
-                    .requiresWithContext(context -> {
+                    .requiresWithContext((context, reader) -> {
                         if (checkCalls.getAndIncrement() == 0) {
                             return false; // called by #parse with arguments
                         }
                         assertThat(context.getArguments().isEmpty(), is(true));
                         assertThat(context.getRange(), equalTo(StringRange.between(0, 7)));
+                        assertThat(reader.getCursor(), is(7));
                         return false;
                     })
                     .suggests((context, builder) -> {

--- a/src/test/java/com/mojang/brigadier/CommandSuggestionsTest.java
+++ b/src/test/java/com/mojang/brigadier/CommandSuggestionsTest.java
@@ -8,6 +8,8 @@ import com.mojang.brigadier.context.StringRange;
 import com.mojang.brigadier.suggestion.Suggestion;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.tree.LiteralCommandNode;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,6 +26,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CommandSuggestionsTest {
@@ -108,6 +111,34 @@ public class CommandSuggestionsTest {
 
         final Suggestions result = subject.getCompletionSuggestions(subject.parse("", source)).join();
 
+        assertThat(result.getRange(), equalTo(StringRange.at(0)));
+        assertThat(result.getList(), is(empty()));
+    }
+
+    @Test
+    public void getCompletionSuggestions_rootCommands_partial_impermissible() throws Exception {
+        subject.register(literal("foo").requires(source -> false));
+
+        final Suggestions result = subject.getCompletionSuggestions(subject.parse("f", source)).join();
+
+        assertThat(result.getRange(), equalTo(StringRange.at(0)));
+        assertThat(result.getList(), is(empty()));
+    }
+
+    @Test
+    public void getCompletionSuggestions_rootCommands_impermissibleContext() throws Exception {
+        subject.register(
+            literal("foo")
+                .requiresWithContext(context -> {
+                    assertThat(context.getRange(), equalTo(StringRange.at(0)));
+                    assertThat(context.getNodes().size(), is(1));
+                    return false;
+                })
+        );
+
+        final Suggestions result = subject.getCompletionSuggestions(subject.parse("", source)).join();
+
+        assertThat(result.getRange(), equalTo(StringRange.at(0)));
         assertThat(result.getList(), is(empty()));
     }
 
@@ -186,14 +217,78 @@ public class CommandSuggestionsTest {
     @Test
     public void getCompletionSuggestions_subCommands_impermissible() throws Exception {
         subject.register(
-                literal("parent")
-                        .then(literal("foo")
-                                .requires(source -> false))
+            literal("parent")
+                .then(literal("foo")
+                    .requires(source -> false)
+                )
         );
 
         final Suggestions result = subject.getCompletionSuggestions(subject.parse("parent ", source)).join();
 
+        assertThat(result.getRange(), equalTo(StringRange.at(0)));
         assertThat(result.getList(), is(empty()));
+    }
+
+    @Test
+    public void getCompletionSuggestions_subCommands_partial_impermissible() throws Exception {
+        subject.register(
+            literal("parent")
+                .then(literal("foo")
+                    .requires(source -> false)
+                )
+        );
+
+        final Suggestions result = subject.getCompletionSuggestions(subject.parse("parent f", source)).join();
+
+        assertThat(result.getRange(), equalTo(StringRange.at(0)));
+        assertThat(result.getList(), is(empty()));
+    }
+
+    @Test
+    public void getCompletionSuggestions_subCommands_impermissibleContext() throws Exception {
+        subject.register(
+            literal("parent")
+                .then(literal("foo")
+                    .requiresWithContext(context -> {
+                        assertThat(context.getRange(), equalTo(StringRange.between(0, 7)));
+                        assertThat(context.getNodes().size(), is(2));
+                        return false;
+                    })
+                )
+        );
+
+        final Suggestions result = subject.getCompletionSuggestions(subject.parse("parent ", source)).join();
+
+        assertThat(result.getRange(), equalTo(StringRange.at(0)));
+        assertThat(result.getList(), is(empty()));
+    }
+
+    @Test
+    public void getCompletionSuggestions_argument_impermissibleContext_with_no_argument() throws Exception {
+        final AtomicInteger checkCalls = new AtomicInteger();
+        subject.register(
+            literal("parent")
+                .then(argument("foo", integer())
+                    .requiresWithContext(context -> {
+                        if (checkCalls.getAndIncrement() == 0) {
+                            return false; // called by #parse with arguments
+                        }
+                        assertThat(context.getArguments().isEmpty(), is(true));
+                        assertThat(context.getRange(), equalTo(StringRange.between(0, 7)));
+                        return false;
+                    })
+                    .suggests((context, builder) -> {
+                        fail();
+                        return null;
+                    })
+                )
+        );
+
+        final Suggestions result = subject.getCompletionSuggestions(subject.parse("parent 123", source)).join();
+
+        assertThat(result.getRange(), equalTo(StringRange.at(0)));
+        assertThat(result.getList(), is(empty()));
+        assertThat(checkCalls.get(), is(2));
     }
 
     @Test

--- a/src/test/java/com/mojang/brigadier/CommandSuggestionsTest.java
+++ b/src/test/java/com/mojang/brigadier/CommandSuggestionsTest.java
@@ -20,6 +20,7 @@ import static com.mojang.brigadier.arguments.IntegerArgumentType.integer;
 import static com.mojang.brigadier.arguments.StringArgumentType.word;
 import static com.mojang.brigadier.builder.LiteralArgumentBuilder.literal;
 import static com.mojang.brigadier.builder.RequiredArgumentBuilder.argument;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -102,6 +103,15 @@ public class CommandSuggestionsTest {
     }
 
     @Test
+    public void getCompletionSuggestions_rootCommands_impermissible() throws Exception {
+        subject.register(literal("foo").requires(source -> false));
+
+        final Suggestions result = subject.getCompletionSuggestions(subject.parse("", source)).join();
+
+        assertThat(result.getList(), is(empty()));
+    }
+
+    @Test
     public void getCompletionSuggestions_subCommands() throws Exception {
         subject.register(
             literal("parent")
@@ -171,6 +181,19 @@ public class CommandSuggestionsTest {
 
         assertThat(result.getRange(), equalTo(StringRange.between(12, 13)));
         assertThat(result.getList(), equalTo(Lists.newArrayList(new Suggestion(StringRange.between(12, 13), "bar"), new Suggestion(StringRange.between(12, 13), "baz"))));
+    }
+
+    @Test
+    public void getCompletionSuggestions_subCommands_impermissible() throws Exception {
+        subject.register(
+                literal("parent")
+                        .then(literal("foo")
+                                .requires(source -> false))
+        );
+
+        final Suggestions result = subject.getCompletionSuggestions(subject.parse("parent ", source)).join();
+
+        assertThat(result.getList(), is(empty()));
     }
 
     @Test


### PR DESCRIPTION
See the description on https://github.com/VelocityPowered/brigadier/commit/37ffa0f384c88a8e14e9892dd7b613cfbe466065.
Making the context-aware predicate take a `ParseResults` object was a mistake, I've moved it to a `CommandContextBuilder` in https://github.com/VelocityPowered/brigadier/commit/b43b3918d800446d2cdeac7a868bae959de95ed9. A nice benefit of this is reduced `ParseResults` allocations if a source cannot use a node.