### PR TITLE
Track the parent context when redirecting

### DIFF
--- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
+++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
@@ -383,7 +383,7 @@ public class CommandDispatcher<S> {
             if (reader.canRead(child.getRedirect() == null ? 2 : 1)) {
                 reader.skip();
                 if (child.getRedirect() != null) {
-                    final CommandContextBuilder<S> childContext = new CommandContextBuilder<>(this, source, child.getRedirect(), reader.getCursor());
+                    final CommandContextBuilder<S> childContext = new CommandContextBuilder<>(this, source, context, child.getRedirect(), reader.getCursor());
                     final ParseResults<S> parse = parseNodes(child.getRedirect(), reader, childContext);
                     context.withChild(parse.getContext());
                     if (child.canUse(context, parse.getReader())) {

--- a/src/main/java/com/mojang/brigadier/context/CommandContext.java
+++ b/src/main/java/com/mojang/brigadier/context/CommandContext.java
@@ -33,11 +33,12 @@ public class CommandContext<S> {
     private final CommandNode<S> rootNode;
     private final List<ParsedCommandNode<S>> nodes;
     private final StringRange range;
+    private CommandContext<S> parent;
     private final CommandContext<S> child;
     private final RedirectModifier<S> modifier;
     private final boolean forks;
 
-    public CommandContext(final S source, final String input, final Map<String, ParsedArgument<S, ?>> arguments, final Command<S> command, final CommandNode<S> rootNode, final List<ParsedCommandNode<S>> nodes, final StringRange range, final CommandContext<S> child, final RedirectModifier<S> modifier, boolean forks) {
+    private CommandContext(final S source, final String input, final Map<String, ParsedArgument<S, ?>> arguments, final Command<S> command, final CommandNode<S> rootNode, final List<ParsedCommandNode<S>> nodes, final StringRange range, final CommandContext<S> parent, final CommandContext<S> child, final RedirectModifier<S> modifier, boolean forks) {
         this.source = source;
         this.input = input;
         this.arguments = arguments;
@@ -50,11 +51,26 @@ public class CommandContext<S> {
         this.forks = forks;
     }
 
+    public CommandContext(final S source, final String input, final Map<String, ParsedArgument<S, ?>> arguments, final Command<S> command, final CommandNode<S> rootNode, final List<ParsedCommandNode<S>> nodes, final StringRange range, final CommandContext<S> child, final RedirectModifier<S> modifier, boolean forks) {
+        this(source, input, arguments, command, rootNode, nodes, range, null, child, modifier, forks);
+    }
+
     public CommandContext<S> copyFor(final S source) {
         if (this.source == source) {
             return this;
         }
-        return new CommandContext<>(source, input, arguments, command, rootNode, nodes, range, child, modifier, forks);
+        return new CommandContext<>(source, input, arguments, command, rootNode, nodes, range, parent, child, modifier, forks);
+    }
+
+    void setParent(final CommandContext<S> parent) {
+        if (this.parent != null) {
+            throw new IllegalArgumentException("Context already has a parent context");
+        }
+        this.parent = parent;
+    }
+
+    public CommandContext<S> getParent() {
+        return parent;
     }
 
     public CommandContext<S> getChild() {
@@ -105,6 +121,7 @@ public class CommandContext<S> {
         if (nodes.size() != that.nodes.size() || !nodes.equals(that.nodes)) return false;
         if (command != null ? !command.equals(that.command) : that.command != null) return false;
         if (!source.equals(that.source)) return false;
+        if (parent != null ? !parent.equals(that.parent) : that.parent != null) return false;
         if (child != null ? !child.equals(that.child) : that.child != null) return false;
 
         return true;
@@ -117,6 +134,7 @@ public class CommandContext<S> {
         result = 31 * result + (command != null ? command.hashCode() : 0);
         result = 31 * result + rootNode.hashCode();
         result = 31 * result + nodes.hashCode();
+        result = 31 * result + (parent != null ? parent.hashCode() : 0);
         result = 31 * result + (child != null ? child.hashCode() : 0);
         return result;
     }

--- a/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
+++ b/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
@@ -319,6 +319,7 @@ public class CommandDispatcherTest {
 
         final CommandContextBuilder<Object> child1 = parse.getContext().getChild();
         assertThat(child1, is(notNullValue()));
+        assertThat(child1.getParent(), is(parse.getContext()));
         assertThat(child1.getRange().get(input), equalTo("redirected"));
         assertThat(child1.getNodes().size(), is(1));
         assertThat(child1.getRootNode(), is(subject.getRoot()));
@@ -327,6 +328,7 @@ public class CommandDispatcherTest {
 
         final CommandContextBuilder<Object> child2 = child1.getChild();
         assertThat(child2, is(notNullValue()));
+        assertThat(child2.getParent(), is(child1));
         assertThat(child2.getRange().get(input), equalTo("actual"));
         assertThat(child2.getNodes().size(), is(1));
         assertThat(child2.getRootNode(), is(subject.getRoot()));


### PR DESCRIPTION
This finally allows us to use Brigadier redirects for command aliases in Velocity.
No more deep cloning of hints and the arguments node :)