### PR TITLE
Revert permission-related suggestion provider changes

### DIFF
--- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
+++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
@@ -6,7 +6,6 @@ package com.mojang.brigadier;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.context.CommandContextBuilder;
-import com.mojang.brigadier.context.StringRange;
 import com.mojang.brigadier.context.SuggestionContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.Suggestions;
@@ -604,18 +603,6 @@ public class CommandDispatcher<S> {
         int i = 0;
         for (final CommandNode<S> node : parent.getChildren()) {
             CompletableFuture<Suggestions> future = Suggestions.empty();
-            if (!node.canUse(context.getSource())) {
-                futures[i++] = future;
-                continue;
-            }
-            // We don't know the real range of the parsed contents; default to an empty range.
-            final CommandContextBuilder<S> nodeContext = context.copy().withNode(node, StringRange.at(start));
-            final StringReader reader = new StringReader(truncatedInput);
-            reader.setCursor(start);
-            if (!node.canUse(nodeContext, reader)) {
-                futures[i++] = future;
-                continue;
-            }
             try {
                 future = node.listSuggestions(context.build(truncatedInput), new SuggestionsBuilder(truncatedInput, truncatedInputLowerCase, start));
             } catch (final CommandSyntaxException ignored) {

--- a/src/main/java/com/mojang/brigadier/context/CommandContextBuilder.java
+++ b/src/main/java/com/mojang/brigadier/context/CommandContextBuilder.java
@@ -9,7 +9,6 @@ import com.mojang.brigadier.RedirectModifier;
 import com.mojang.brigadier.tree.CommandNode;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/com/mojang/brigadier/CommandSuggestionsTest.java
+++ b/src/test/java/com/mojang/brigadier/CommandSuggestionsTest.java
@@ -20,7 +20,6 @@ import static com.mojang.brigadier.arguments.IntegerArgumentType.integer;
 import static com.mojang.brigadier.arguments.StringArgumentType.word;
 import static com.mojang.brigadier.builder.LiteralArgumentBuilder.literal;
 import static com.mojang.brigadier.builder.RequiredArgumentBuilder.argument;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;

--- a/src/test/java/com/mojang/brigadier/CommandSuggestionsTest.java
+++ b/src/test/java/com/mojang/brigadier/CommandSuggestionsTest.java
@@ -8,8 +8,6 @@ import com.mojang.brigadier.context.StringRange;
 import com.mojang.brigadier.suggestion.Suggestion;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.tree.LiteralCommandNode;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,7 +24,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CommandSuggestionsTest {
@@ -106,44 +103,6 @@ public class CommandSuggestionsTest {
     }
 
     @Test
-    public void getCompletionSuggestions_rootCommands_impermissible() throws Exception {
-        subject.register(literal("foo").requires(source -> false));
-
-        final Suggestions result = subject.getCompletionSuggestions(subject.parse("", source)).join();
-
-        assertThat(result.getRange(), equalTo(StringRange.at(0)));
-        assertThat(result.getList(), is(empty()));
-    }
-
-    @Test
-    public void getCompletionSuggestions_rootCommands_partial_impermissible() throws Exception {
-        subject.register(literal("foo").requires(source -> false));
-
-        final Suggestions result = subject.getCompletionSuggestions(subject.parse("f", source)).join();
-
-        assertThat(result.getRange(), equalTo(StringRange.at(0)));
-        assertThat(result.getList(), is(empty()));
-    }
-
-    @Test
-    public void getCompletionSuggestions_rootCommands_impermissibleContext() throws Exception {
-        subject.register(
-            literal("foo")
-                .requiresWithContext((context, reader) -> {
-                    assertThat(context.getRange(), equalTo(StringRange.at(0)));
-                    assertThat(context.getNodes().size(), is(1));
-                    assertThat(reader.getCursor(), is(0));
-                    return false;
-                })
-        );
-
-        final Suggestions result = subject.getCompletionSuggestions(subject.parse("", source)).join();
-
-        assertThat(result.getRange(), equalTo(StringRange.at(0)));
-        assertThat(result.getList(), is(empty()));
-    }
-
-    @Test
     public void getCompletionSuggestions_subCommands() throws Exception {
         subject.register(
             literal("parent")
@@ -213,85 +172,6 @@ public class CommandSuggestionsTest {
 
         assertThat(result.getRange(), equalTo(StringRange.between(12, 13)));
         assertThat(result.getList(), equalTo(Lists.newArrayList(new Suggestion(StringRange.between(12, 13), "bar"), new Suggestion(StringRange.between(12, 13), "baz"))));
-    }
-
-    @Test
-    public void getCompletionSuggestions_subCommands_impermissible() throws Exception {
-        subject.register(
-            literal("parent")
-                .then(literal("foo")
-                    .requires(source -> false)
-                )
-        );
-
-        final Suggestions result = subject.getCompletionSuggestions(subject.parse("parent ", source)).join();
-
-        assertThat(result.getRange(), equalTo(StringRange.at(0)));
-        assertThat(result.getList(), is(empty()));
-    }
-
-    @Test
-    public void getCompletionSuggestions_subCommands_partial_impermissible() throws Exception {
-        subject.register(
-            literal("parent")
-                .then(literal("foo")
-                    .requires(source -> false)
-                )
-        );
-
-        final Suggestions result = subject.getCompletionSuggestions(subject.parse("parent f", source)).join();
-
-        assertThat(result.getRange(), equalTo(StringRange.at(0)));
-        assertThat(result.getList(), is(empty()));
-    }
-
-    @Test
-    public void getCompletionSuggestions_subCommands_impermissibleContext() throws Exception {
-        subject.register(
-            literal("parent")
-                .then(literal("foo")
-                    .requiresWithContext((context, reader) -> {
-                        assertThat(context.getRange(), equalTo(StringRange.between(0, 7)));
-                        assertThat(context.getNodes().size(), is(2));
-                        assertThat(reader.getCursor(), is(7));
-                        return false;
-                    })
-                )
-        );
-
-        final Suggestions result = subject.getCompletionSuggestions(subject.parse("parent ", source)).join();
-
-        assertThat(result.getRange(), equalTo(StringRange.at(0)));
-        assertThat(result.getList(), is(empty()));
-    }
-
-    @Test
-    public void getCompletionSuggestions_argument_impermissibleContext_with_no_argument() throws Exception {
-        final AtomicInteger checkCalls = new AtomicInteger();
-        subject.register(
-            literal("parent")
-                .then(argument("foo", integer())
-                    .requiresWithContext((context, reader) -> {
-                        if (checkCalls.getAndIncrement() == 0) {
-                            return false; // called by #parse with arguments
-                        }
-                        assertThat(context.getArguments().isEmpty(), is(true));
-                        assertThat(context.getRange(), equalTo(StringRange.between(0, 7)));
-                        assertThat(reader.getCursor(), is(7));
-                        return false;
-                    })
-                    .suggests((context, builder) -> {
-                        fail();
-                        return null;
-                    })
-                )
-        );
-
-        final Suggestions result = subject.getCompletionSuggestions(subject.parse("parent 123", source)).join();
-
-        assertThat(result.getRange(), equalTo(StringRange.at(0)));
-        assertThat(result.getList(), is(empty()));
-        assertThat(checkCalls.get(), is(2));
     }
 
     @Test


### PR DESCRIPTION
This reverts commits bba30e1674467dbdb35c51d5304c76fa3ae13837 and 08588fa6553c8773e6ed842e60a3c983645c3b69.

These changes unfortunately made too many `CommandContextBuilder` allocations and requirement checks. It turns out we can make these changes on Velocity's side instead of modifying Brigadier, while ensuring we only ask candidate nodes for permission exactly once. A nice side-effect is that suggestions now follow the vanilla client's behavior exactly.