### PR TITLE
Make sure we get Java 8 version module file.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,16 @@ test {
     }
 }
 
+def targetJavaVersion = 8
+java {
+    def javaVersion = JavaVersion.toVersion(targetJavaVersion)
+    sourceCompatibility = javaVersion
+    targetCompatibility = javaVersion
+    if (JavaVersion.current() < javaVersion) {
+        toolchain.languageVersion = JavaLanguageVersion.of(targetJavaVersion)
+    }
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) {

--- a/build.gradle
+++ b/build.gradle
@@ -66,9 +66,6 @@ java {
     def javaVersion = JavaVersion.toVersion(targetJavaVersion)
     sourceCompatibility = javaVersion
     targetCompatibility = javaVersion
-    if (JavaVersion.current() < javaVersion) {
-        toolchain.languageVersion = JavaLanguageVersion.of(targetJavaVersion)
-    }
 }
 
 publishing {


### PR DESCRIPTION
Fix java 8 issues when using Velocity API.
Exactly fixed this:
```
...
Required by:
    project :velocity > com.velocitypowered:velocity-api:3.1.1

> No matching variant of com.velocitypowered:velocity-brigadier:1.0.0-SNAPSHOT:20230302.050516-1 was found. ....
- Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8
- Other compatible attribute:
    - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
```